### PR TITLE
Update README to use correct ember install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This Ember CLI addon is a simple wrapper for [ChartJS](http://www.chartjs.org/) 
 ### Installation
 
 ```
-$ ember install ember-cli-chart
+$ ember install ember-cli-chartjs
 ```
 
 ### Usage


### PR DESCRIPTION
Thanks for making this addon. 
During install, I just copy/pasted the command in the readme and it took me a while to figure out why ChartJS was not working as expected - I was using the old version from the repo you cloned.

Changed the README ember install command from 

`$ ember install ember-cli-chart`

to

`$ ember install ember-cli-chartjs`
