### PR TITLE
Update chart when chart type/options change

### DIFF
--- a/addon/components/ember-chart.js
+++ b/addon/components/ember-chart.js
@@ -62,8 +62,8 @@ export default Ember.Component.extend({
 			this.addObserver('data', this, this.updateChart);
 			this.addObserver('data.[]', this, this.updateChart);
 		}
-		this.addObserver('options', this, this.updateChart);
-		this.addObserver('type', this, this.chartTypeChanged);
+		this.addObserver('options', this, this.redrawChart);
+		this.addObserver('type', this, this.redrawChart);
 	},
 
   createChart: function() {
@@ -111,11 +111,11 @@ export default Ember.Component.extend({
 		this.removeObserver('model.[]', this, this.updateChart);
 		this.removeObserver('_page', this, this.updateChart);
 		this.removeObserver('colors.[]', this, this.updateChart);
-		this.removeObserver('options', this, this.updateChart);
-		this.removeObserver('type', this, this.chartTypeChanged);
+		this.removeObserver('options', this, this.redrawChart);
+		this.removeObserver('type', this, this.redrawChart);
 	},
 
-  chartTypeChanged: function() {
+  redrawChart: function() {
     var existingChart = this.get('chart');
     if (existingChart) {
       existingChart.destroy();

--- a/addon/components/ember-chart.js
+++ b/addon/components/ember-chart.js
@@ -42,6 +42,31 @@ export default Ember.Component.extend({
 	didInsertElement() {
 		this._super(...arguments);
 
+    var chart = this.createChart();
+
+		this.set('chart', chart);
+
+		if(this.get('isModel'))
+		{
+      var _chartObject = this.get('_chartObject');
+			_chartObject.set('__chart', chart);
+			this.set('_chartObject', _chartObject);
+
+			this.addObserver('model', this, this.updateChart);
+			this.addObserver('model.[]', this, this.updateChart);
+			this.addObserver('_page', this, this.updateChart);
+			this.addObserver('colors.[]', this, this.updateChart);
+		}
+		else
+		{
+			this.addObserver('data', this, this.updateChart);
+			this.addObserver('data.[]', this, this.updateChart);
+		}
+		this.addObserver('options', this, this.updateChart);
+		this.addObserver('type', this, this.chartTypeChanged);
+	},
+
+  createChart: function() {
 		let _chartObject;
 		if(!Ember.isNone(this.get('model')))
 		{
@@ -63,36 +88,18 @@ export default Ember.Component.extend({
 			_chartObject = this.get('data');
 		}
 
+    this.set('_chartObject', _chartObject);
+
 		const context = this.$().find('canvas').get(0);
 		const type    = this.get('type');
 		const options = this.setDefaultOptions(this.get('options'));
 
-		const chart = new Chart(context, {
+		return new Chart(context, {
 			type: type,
 			data: _chartObject,
 			options: options
 		});
-
-
-		this.set('chart', chart);
-
-		if(this.get('isModel'))
-		{
-			_chartObject.set('__chart', chart);
-			this.set('_chartObject', _chartObject);
-
-			this.addObserver('model', this, this.updateChart);
-			this.addObserver('model.[]', this, this.updateChart);
-			this.addObserver('_page', this, this.updateChart);
-			this.addObserver('colors.[]', this, this.updateChart);
-		}
-		else
-		{
-			this.addObserver('data', this, this.updateChart);
-			this.addObserver('data.[]', this, this.updateChart);
-		}
-		this.addObserver('options', this, this.updateChart);
-	},
+  },
 
 	willDestroyElement() {
 		this._super(...arguments);
@@ -105,140 +112,149 @@ export default Ember.Component.extend({
 		this.removeObserver('_page', this, this.updateChart);
 		this.removeObserver('colors.[]', this, this.updateChart);
 		this.removeObserver('options', this, this.updateChart);
+		this.removeObserver('type', this, this.chartTypeChanged);
 	},
 
-	setDefaultOptions(options) {
-		const _this = this;
+  chartTypeChanged: function() {
+    var existingChart = this.get('chart');
+    if (existingChart) {
+      existingChart.destroy();
+    }
+    this.set('chart', this.createChart());
+  },
 
-		// set options
-		options = options || {};
+  setDefaultOptions(options) {
+    const _this = this;
 
-		// set onClick options
-		let oldOnClick = function(){};
-		if(options.onClick) {oldOnClick = options.onClick;}
+    // set options
+    options = options || {};
 
-		options.onClick = function() {
-			_this.clickAction.apply(_this, arguments);
-			oldOnClick.apply(this, arguments);
-		};
+    // set onClick options
+    let oldOnClick = function(){};
+    if(options.onClick) {oldOnClick = options.onClick;}
 
-		// set legend options
-		options.legend = options.legend || {};
+    options.onClick = function() {
+      _this.clickAction.apply(_this, arguments);
+      oldOnClick.apply(this, arguments);
+    };
 
-		setDefault(options.legend, 'display', true);
-		setDefault(options.legend, 'position', 'bottom');
-		setDefault(options.legend, 'fullWidth', true);
+    // set legend options
+    options.legend = options.legend || {};
 
-		// set tooltip options
-		options.tooltips = options.tooltips || {};
+    setDefault(options.legend, 'display', true);
+    setDefault(options.legend, 'position', 'bottom');
+    setDefault(options.legend, 'fullWidth', true);
 
-		setDefault(options.tooltips, 'enabled', true);
-		setDefault(options.tooltips, 'mode', 'single');
-		setDefault(options.tooltips, 'backgroundColor', 'rgba(240,240,240,1)');
-		setDefault(options.tooltips, 'titleFontColor', '#444');
-		setDefault(options.tooltips, 'bodyFontColor', '#444');
-		setDefault(options.tooltips, 'bodySpacing', '0');
-		setDefault(options.tooltips, 'bodyFontStyle', 'italic');
-		setDefault(options.tooltips, 'footerFontColor', '#444');
-		setDefault(options.tooltips, 'xPadding', 10);
-		setDefault(options.tooltips, 'yPadding', 15);
-		setDefault(options.tooltips, 'caretSize', 10);
-		setDefault(options.tooltips, 'cornerRadius', 3);
-		setDefault(options.tooltips, 'multiKeybackground', '#999');
+    // set tooltip options
+    options.tooltips = options.tooltips || {};
 
-		// set tooltip callbacks
-		options.tooltips.callbacks = options.tooltips.callbacks || {};
+    setDefault(options.tooltips, 'enabled', true);
+    setDefault(options.tooltips, 'mode', 'single');
+    setDefault(options.tooltips, 'backgroundColor', 'rgba(240,240,240,1)');
+    setDefault(options.tooltips, 'titleFontColor', '#444');
+    setDefault(options.tooltips, 'bodyFontColor', '#444');
+    setDefault(options.tooltips, 'bodySpacing', '0');
+    setDefault(options.tooltips, 'bodyFontStyle', 'italic');
+    setDefault(options.tooltips, 'footerFontColor', '#444');
+    setDefault(options.tooltips, 'xPadding', 10);
+    setDefault(options.tooltips, 'yPadding', 15);
+    setDefault(options.tooltips, 'caretSize', 10);
+    setDefault(options.tooltips, 'cornerRadius', 3);
+    setDefault(options.tooltips, 'multiKeybackground', '#999');
 
-		setDefault(options.tooltips.callbacks, 'label', function(tooltip, data) {
-			const label = data.labels[tooltip.index];
-			const value = data.datasets[tooltip.datasetIndex].data[tooltip.index];
+    // set tooltip callbacks
+    options.tooltips.callbacks = options.tooltips.callbacks || {};
 
-			if(Ember.isEmpty(label))
-			{
-				if(Ember.isEmpty(value))
-				{
-					return;
-				}
-				return value;
-			}
-			else if(Ember.isEmpty(value))
-			{
-				return label;
-			}
+    setDefault(options.tooltips.callbacks, 'label', function(tooltip, data) {
+      const label = data.labels[tooltip.index];
+      const value = data.datasets[tooltip.datasetIndex].data[tooltip.index];
 
-			return _this.tooltip(label, value);
-		});
+      if(Ember.isEmpty(label))
+      {
+        if(Ember.isEmpty(value))
+        {
+          return;
+        }
+        return value;
+      }
+      else if(Ember.isEmpty(value))
+      {
+        return label;
+      }
 
-		// return options with defaults
-		return options;
-	},
+      return _this.tooltip(label, value);
+    });
 
-	clickAction(evt, segment) {
-		if(this.get('isModel')) {
-			segment = segment[0] || {};
-			let segmentModel = segment._model;
-			if(segmentModel && segmentModel.label === 'Other') {
-				this.set('_page', this.get('_page') + 1);
-				this.set('showBackButton', true);
-			} else if(segmentModel && segmentModel.label) {
-				let index = ((this.get('colors.length') - 2) * this.get('_page')) + segment._index;
-				let model = this.get('_chartObject').getModel(index);
-				if(!Ember.isNone(model)) {
-					this.sendAction('onClick', model);
-				}
-			}
-		} else {
-			this.sendAction('onClick', evt, segment);
-		}
-	},
+    // return options with defaults
+    return options;
+  },
 
-	tooltip(label, value) {
-		return label + ': ' + value;
-	},
+  clickAction(evt, segment) {
+    if(this.get('isModel')) {
+      segment = segment[0] || {};
+      let segmentModel = segment._model;
+      if(segmentModel && segmentModel.label === 'Other') {
+        this.set('_page', this.get('_page') + 1);
+        this.set('showBackButton', true);
+      } else if(segmentModel && segmentModel.label) {
+        let index = ((this.get('colors.length') - 2) * this.get('_page')) + segment._index;
+        let model = this.get('_chartObject').getModel(index);
+        if(!Ember.isNone(model)) {
+          this.sendAction('onClick', model);
+        }
+      }
+    } else {
+      this.sendAction('onClick', evt, segment);
+    }
+  },
 
-	updateChart() {
-		let data;
-		if(this.get('isModel')) {
-			data = this.get('_chartObject');
-			if(this.get('model.length') !== data.get('model.length'))
-			{
-				data.set('model', this.get('model'));
-			}
+  tooltip(label, value) {
+    return label + ': ' + value;
+  },
 
-			if(this.get('colors.length') !== data.get('colors.length'))
-			{
-				data.set('colors', this.get('colors'));
-			}
+  updateChart() {
+    let data;
+    if(this.get('isModel')) {
+      data = this.get('_chartObject');
+      if(this.get('model.length') !== data.get('model.length'))
+      {
+        data.set('model', this.get('model'));
+      }
 
-			if(this.get('_page') !== data.get('page'))
-			{
-				data.set('page', this.get('_page'));
-			}
-		} else {
-			data = this.get('data');
-			const chart = this.get('chart');
-			chart.config.data = data;
-			chart.update();
-		}
-	},
+      if(this.get('colors.length') !== data.get('colors.length'))
+      {
+        data.set('colors', this.get('colors'));
+      }
 
-	buttonDisplay: Ember.computed('showBackButton', function() {
-		if(this.get('showBackButton')) {
-			return Ember.String.htmlSafe('display:block; position:absolute; top:0; left:0;');
-		}
+      if(this.get('_page') !== data.get('page'))
+      {
+        data.set('page', this.get('_page'));
+      }
+    } else {
+      data = this.get('data');
+      const chart = this.get('chart');
+      chart.config.data = data;
+      chart.update();
+    }
+  },
 
-		return Ember.String.htmlSafe('display:none; position:absolute;');
-	}),
+  buttonDisplay: Ember.computed('showBackButton', function() {
+    if(this.get('showBackButton')) {
+      return Ember.String.htmlSafe('display:block; position:absolute; top:0; left:0;');
+    }
 
-	actions: {
-		backAction() {
-			let segments = (this.get('_page') - 1);
-			if(segments <= 0) {
-				segments = 0;
-				this.set('showBackButton', false);
-			}
+    return Ember.String.htmlSafe('display:none; position:absolute;');
+  }),
 
-			this.set('_page', segments);
-		}
-	}
+  actions: {
+    backAction() {
+      let segments = (this.get('_page') - 1);
+      if(segments <= 0) {
+        segments = 0;
+        this.set('showBackButton', false);
+      }
+
+      this.set('_page', segments);
+    }
+  }
 });

--- a/tests/unit/components/ember-chart-test.js
+++ b/tests/unit/components/ember-chart-test.js
@@ -122,3 +122,21 @@ test('it should update charts dynamically', function(assert) {
   chart = component.get('chart');
   assert.equal(chart.data.labels[0], 'December');
 });
+
+test('it should rebuild the chart (line -> bar) if the chart type changes', function(assert) {
+  var component = this.subject({
+    type: 'line',
+    data: testData.get('lineData')
+  });
+
+  this.render();
+  var chart = component.get('chart');
+  assert.equal(chart.config.type, 'line');
+
+  //Update Type -- change to bar type
+  component.set('type', 'bar');
+
+  chart = component.get('chart');
+
+  assert.equal(chart.config.type, 'bar');
+});

--- a/tests/unit/components/ember-chart-test.js
+++ b/tests/unit/components/ember-chart-test.js
@@ -16,9 +16,9 @@ test('it can be a pie chart', function(assert) {
   var component = this.subject({
     type: 'pie',
     model: testData.get('pieModelData'),
-	labelPath: 'label',
-	dataPath: 'value',
-	colors: testData.get('pieModelDataColors')
+    labelPath: 'label',
+    dataPath: 'value',
+    colors: testData.get('pieModelDataColors')
   });
 
   this.render();
@@ -121,6 +121,28 @@ test('it should update charts dynamically', function(assert) {
 
   chart = component.get('chart');
   assert.equal(chart.data.labels[0], 'December');
+});
+
+test('it should update chart options dynamically', function(assert) {
+  var component = this.subject({
+    type: 'bar',
+    data: testData.get('lineData')
+  });
+
+  this.render();
+  var chart = component.get('chart');
+
+  assert.equal(chart.config.type, 'bar');
+  assert.equal(chart.data.datasets.length, 2);
+  assert.equal(chart.options.responsive, true);
+  assert.equal(chart.config.options.responsive, true);
+
+  var options = { responsive: false };
+  component.set('options', options);
+
+  chart = component.get('chart');
+  assert.equal(chart.options.responsive, false);
+  assert.equal(chart.config.options.responsive, false);
 });
 
 test('it should rebuild the chart (line -> bar) if the chart type changes', function(assert) {


### PR DESCRIPTION
This change allows the chart type to be changed (ie `line --> bar`) or when options change (ie `responsive:true --> responsive:false`). Tests are added to confirm that these new features work.

Largely borrowed from https://github.com/aomran/ember-cli-chart/pull/50.

Sorry, the diff makes it look like a much larger change than it actually is, the change actually made is...
1. break out creating a chart into its own function
2. add/remove observer to `type` variable
3. add `redrawChart()` function.
4. add/remove observer for 'options' to run `redrawChart()` function.
