### PR TITLE
fix default tooltip option bodySpacing type to Number

### DIFF
--- a/addon/components/ember-chart.js
+++ b/addon/components/ember-chart.js
@@ -214,7 +214,7 @@ export default Ember.Component.extend({
 		setDefault(options.tooltips, 'backgroundColor', 'rgba(240,240,240,1)');
 		setDefault(options.tooltips, 'titleFontColor', '#444');
 		setDefault(options.tooltips, 'bodyFontColor', '#444');
-		setDefault(options.tooltips, 'bodySpacing', '0');
+		setDefault(options.tooltips, 'bodySpacing', 0);
 		setDefault(options.tooltips, 'bodyFontStyle', 'italic');
 		setDefault(options.tooltips, 'footerFontColor', '#444');
 		setDefault(options.tooltips, 'xPadding', 10);


### PR DESCRIPTION
This PR is a simple fix to the default `bodySpacing` value from string `'0'` to number `0` per the  [tooltip](http://www.chartjs.org/docs/#chart-configuration-tooltip-configuration) config options for `bodySpacing`. I was noticing when using multiline tooltips (like with option `mode: 'label'`), the second tooltip item wasn't displaying because of the current `bodySpacing` defaults.
